### PR TITLE
Chrome 拡張機能 Manifest V3 への対応

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "name": "MyレコーダーChromeアシスタント",
   "short_name": "Myレコーダーアシスト",
-  "version": "0.6.0",
-  "manifest_version": 2,
+  "version": "0.7.0",
+  "manifest_version": 3,
   "description": "勤怠管理システム「Myレコーダー | KING OF TIME」を快適に使えるようにするための拡張機能です。",
   "icons": {
     "16": "icons/icon16.png",
@@ -13,17 +13,19 @@
     "page": "src/options/options.html",
     "open_in_tab": true
   },
-  "browser_action": {
+  "action": {
     "default_icon": "icons/icon19.png",
     "default_title": "Myレコーダーアシスタント",
     "default_popup": "src/browser_action/browser_action.html"
   },
   "permissions": [
+    "storage"
+  ],
+  "host_permissions": [
     "https://s2.kingtime.jp/independent/recorder/personal/*",
     "https://s3.kingtime.jp/independent/recorder/personal/*",
     "https://slack.com/api/*",
-    "https://hooks.slack.com/services/*",
-    "storage"
+    "https://hooks.slack.com/services/*"
   ],
   "content_scripts": [
     {
@@ -38,7 +40,6 @@
     }
   ],
   "background": {
-    "scripts": ["src/background/background.js"],
-    "persistent": false
+    "service_worker": "src/background/background.js"
   }
 }


### PR DESCRIPTION
## 概要
「Chrome 拡張機能 Manifest V3 への対応 #28」の対応です。
See: https://github.com/shoito/kot-chrome-assistant/issues/28

* manifest.jsonの変更点
  * manifest_versionを 3 へ
  * permissionsの内容をhost_permissionsとそれ以外で分ける
  * backgroundの内容をService Worker化
  * xxx_actionをactionへ統合
  * バージョンの修正
    * これまでのコミットログをみて、今回はメジャーバージョンレベルでもマイクロバージョンレベルでもない修正と判断したので、マイナーバージョンアップを行いました。
* 変更しない点
  * ロジック修正
    * chrome.browserActionやchrome.pageAction, chrome. webRequestの利用はないので、特に対応不要という判断です

## ToDos

- [x] 公式のガイドを確認
  - Migrating to Manifest V3 - Chrome Developers https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/
  - Manifest V3 migration checklist - Chrome Developers https://developer.chrome.com/docs/extensions/mv3/mv3-migration-checklist/
    - 「API Checklist」に基づいて既存のコードを確認していく
- [x] 今回修正すべき点の洗い出し
  - manifest.jsonの変更点
    - manifest_versionを `3` へ
    - permissionsの内容をhost_permissionsとそれ以外で分ける
    - backgroundの内容をService Worker化
    - xxx_actionをactionへ統合
    - バージョンの修正
      - どのレベルのバージョンを上げるかは要確認
  - 変更しない点
    - ロジック修正はなし
      - chrome.browserActionやchrome.pageAction, chrome. webRequestの利用はないので、特に対応不要
- [x] 修正
- [x] 動作確認