### PR TITLE
feat: SAML認証をサポート

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "MyレコーダーChromeアシスタント",
   "short_name": "Myレコーダーアシスト",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "manifest_version": 3,
   "description": "勤怠管理システム「Myレコーダー | KING OF TIME」を快適に使えるようにするための拡張機能です。",
   "icons": {
@@ -19,7 +19,8 @@
     "default_popup": "src/browser_action/browser_action.html"
   },
   "permissions": [
-    "storage"
+    "storage",
+    "geolocation"
   ],
   "host_permissions": [
     "https://s2.kingtime.jp/independent/recorder/personal/*",
@@ -31,7 +32,9 @@
     {
       "matches": [
         "https://s2.kingtime.jp/independent/recorder/personal/*",
-        "https://s3.kingtime.jp/independent/recorder/personal/*"
+        "https://s3.kingtime.jp/independent/recorder/personal/*",
+        "https://s2.ta.kingoftime.jp/independent/recorder2/personal/*",
+        "https://s3.ta.kingoftime.jp/independent/recorder2/personal/*"
       ],
       "js": [
         "src/inject/inject.js"

--- a/src/browser_action/browser_action.html
+++ b/src/browser_action/browser_action.html
@@ -33,7 +33,7 @@
 
 <body>
 	<div id="myrec">
-		<iframe src="https://s2.kingtime.jp/independent/recorder/personal/" width="100%" height="100%"></iframe>
+		<iframe src="https://s2.kingtime.jp/independent/recorder/personal/" width="100%" height="100%" allow="geolocation;"></iframe>
 	</div>
 	<div id="notice"></div>
 	<script src="browser_action.js"></script>

--- a/src/browser_action/browser_action.js
+++ b/src/browser_action/browser_action.js
@@ -1,24 +1,41 @@
 let myrecUrl = "https://s2.kingtime.jp/independent/recorder/personal/";
 
 const replaceMyrecToNeed = () => {
-  chrome.storage.sync.get([
-    's3Selected'
-  ], (items) => {
+  chrome.storage.sync.get(["s3Selected", "samlSelected"], (items) => {
     if (items.s3Selected) {
-      const iframe = document.querySelector('#myrec iframe');
+      if (items.samlSelected) {
+        const iframe = document.querySelector("#myrec iframe");
+        if (iframe) {
+          myrecUrl = "https://s3.ta.kingoftime.jp/independent/recorder2/personal/";
+          iframe.src = myrecUrl;
+        }
+        return
+      }
+      const iframe = document.querySelector("#myrec iframe");
       if (iframe) {
         myrecUrl = "https://s3.kingtime.jp/independent/recorder/personal/";
         iframe.src = myrecUrl;
       }
+      return;
+    }
+    if (items.samlSelected) {
+      const iframe = document.querySelector("#myrec iframe");
+      if (iframe) {
+        myrecUrl = "https://s2.ta.kingoftime.jp/independent/recorder2/personal/";
+        iframe.src = myrecUrl;
+      }
+      return
     }
   });
-}
+};
 
 replaceMyrecToNeed();
 
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
-  if (msg && msg.contentScriptQuery === 'NOT_LOGGED_IN') {
-    document.getElementById('notice').innerHTML = `<div class="notification is-info"><a href="${myrecUrl}" target="blank">Myレコーダー</a>から事前のログインとページの再読み込みをしてください。</div>`
+  if (msg && msg.contentScriptQuery === "NOT_LOGGED_IN") {
+    document.getElementById(
+      "notice"
+    ).innerHTML = `<div class="notification is-info"><a href="${myrecUrl}" target="blank">Myレコーダー</a>から事前のログインとページの再読み込みをしてください。</div>`;
   }
 
   return true;

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -346,6 +346,25 @@
 
                 </div>
 
+                <h4>KING OF TIME 認証設定</h4>
+                <div id="saml-settings" class="box">
+
+                    <div class="field is-horizontal">
+                    <div class="field-label is-normal">
+                        <label class="label">認証切り替え</label>
+                    </div>
+                    <div class="field-body">
+                        <label class="radio">
+                            <input id="accountSelected" name="saml" type="radio">ユーザー認証
+                        </label>
+                        <label class="radio">
+                            <input id="samlSelected" name="saml" type="radio">SAML認証
+                        </label>
+                    </div>
+                    </div>
+
+                </div>
+
                 <h4>お試しボタン</h4>
                 <div id="debuggable-settings" class="box">
 

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -82,7 +82,10 @@ const restoreOptions = () => {
     "slackStatusToken",
 
     // KING OF TIME Domain
-    "s3Selected"
+    "s3Selected",
+
+    // KING OF TIME Authentication
+    "samlSelected"
   ], (items) => {
     document.getElementById('debuggable').checked = items.debuggable;
 
@@ -107,6 +110,9 @@ const restoreOptions = () => {
 
     document.getElementById('s2Selected').checked = !items.s3Selected;
     document.getElementById('s3Selected').checked = items.s3Selected;
+
+    document.getElementById('accountSelected').checked = !items.samlSelected;
+    document.getElementById('samlSelected').checked = items.samlSelected;
   });
 }
 
@@ -213,6 +219,14 @@ document.getElementById('s2Selected').addEventListener('change', () => {
 
 document.getElementById('s3Selected').addEventListener('change', () => {
   chrome.storage.sync.set({s3Selected: true});
+});
+
+document.getElementById('accountSelected').addEventListener('change', () => {
+  chrome.storage.sync.set({samlSelected: false});
+});
+
+document.getElementById('samlSelected').addEventListener('change', () => {
+  chrome.storage.sync.set({samlSelected: true});
 });
 
 document.getElementById('debuggable').addEventListener('click', () => {


### PR DESCRIPTION
## 目的
SAML認証を導入している場合に使用できなかったため、SAML認証を追加しました！

## 対応した内容
- オプションページにSAML認証切り替え設定を追加
- アクションページに位置情報の連携を追加

## 対応していない内容
- 使用している環境下でのドメインを追加していますので他のパターンに対しては対応しておりません！

## スクリーンショット
![image](https://user-images.githubusercontent.com/15701307/199143273-aa015de7-d02a-4640-8b34-0cff3cdc12f6.png)
