### PR TITLE
休始/休終ボタンの誤操作防止対策 #33

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "MyレコーダーChromeアシスタント",
   "short_name": "Myレコーダーアシスト",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "manifest_version": 3,
   "description": "勤怠管理システム「Myレコーダー | KING OF TIME」を快適に使えるようにするための拡張機能です。",
   "icons": {

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -40,12 +40,15 @@
       todayHistoryItem = localStorage.getItem('PARSONAL_BROWSER_RECORDER@RECORD_HISTORY_' + setting.user.user_token),
       todayHistories = JSON.parse(todayHistoryItem ? todayHistoryItem : '[]').filter(i => i.send_timestamp.startsWith(today)),
       isClockedIn = todayHistories.some(h=>h.name === '出勤'),
-      isClockedOut = todayHistories.some(h=>h.name === '退勤');
+      isClockedOut = todayHistories.some(h=>h.name === '退勤'),
+      isBreakStart = todayHistories[0]?.name === '休始';
 
   let intervalCount = 0;
   const interval = setInterval(() => {
     const clockInButton = document.querySelector('.record-clock-in'),
-          clockOutButton = document.querySelector('.record-clock-out');
+          clockOutButton = document.querySelector('.record-clock-out'),
+          breakStartButton = [...document.querySelectorAll(".record-btn-inner")].filter(v=>v.textContent==="休始")[0],
+          breakFinishButton = [...document.querySelectorAll(".record-btn-inner")].filter(v=>v.textContent==="休終")[0];
 
     if (!(clockInButton && clockOutButton)) {
       if (++intervalCount > 30) {
@@ -58,6 +61,12 @@
 
     if (isClockedIn) clockInButton.style.opacity = 0.3;
     if (isClockedOut) clockOutButton.style.opacity = 0.3;
+
+    if (breakStartButton && breakFinishButton) {
+      if (isBreakStart) clockOutButton.style.opacity = 0.3;
+      if (!isClockedIn || isClockedOut || (isClockedIn && isBreakStart) ) breakStartButton.style.opacity = 0.3;
+      if (!isBreakStart) breakFinishButton.style.opacity = 0.3;
+    }
 
     const buttons = setting.timerecorder.record_button,
           clockInButtonId = buttons.filter(b => b.mark === '1')[0].id,


### PR DESCRIPTION
## 対応した内容

- #33 
  - localStorageのステータスに応じて休始/休終ボタンをグレーアウトする実装を追加

## 実装内容

- 出勤前
![スクリーンショット 2022-12-30 2 07 00](https://user-images.githubusercontent.com/15701307/209987507-d3cd7826-2719-44ed-b4b0-93855f575b0d.png)

- 勤務中
![スクリーンショット 2022-12-30 2 07 22](https://user-images.githubusercontent.com/15701307/209987566-f3667a99-202f-4093-95fc-8952f4b58f51.png)

- 休憩中
![スクリーンショット 2022-12-30 2 07 49](https://user-images.githubusercontent.com/15701307/209987596-7ae62bdc-20bd-4ed6-9ba5-f8160e468be2.png)

- 休憩終了
![スクリーンショット 2022-12-30 2 08 17](https://user-images.githubusercontent.com/15701307/209987609-2d1d7f20-60a1-4f73-b46b-4976980d6cf8.png)

- 退勤後
![スクリーンショット 2022-12-30 2 08 53](https://user-images.githubusercontent.com/15701307/209987645-56cba1a6-ce07-45f2-a2f9-be91b048cd62.png)

## 未対応事項

- 外部ツール（モバイルアプリやWebAPIでの打刻）で打刻した場合、反映されない問題には未対応