### PR TITLE
複数ワークスペースへの通知ができるようにする

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "MyレコーダーChromeアシスタント",
   "short_name": "Myレコーダーアシスト",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "manifest_version": 3,
   "description": "勤怠管理システム「Myレコーダー | KING OF TIME」を快適に使えるようにするための拡張機能です。",
   "icons": {

--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -167,22 +167,17 @@
   const postMessage = (message) => {
     if (!slackEnabled || !message || message.length === 0) return;
 
-    const headers = {
-      'Content-Type': 'application/json; charset=utf-8',
-      'Access-Control-Allow-Origin': '*'
-    };
-
     if (slackApiType === 'asUser') {
       const slackTokens = slackToken.split(' '); // Multiple workspaces post support
       const slackChannels = slackChannel.split(' '); // Multiple channels post support
-      for (let i = 0; i < slackTokens.length; i++) {
+      for (let i = 0; i < slackChannels.length; i++) {
         chrome.runtime.sendMessage(
           {
             contentScriptQuery: 'postMessage',
             headers: {
               'Content-Type': 'application/json; charset=utf-8',
               'Access-Control-Allow-Origin': '*',
-              'Authorization': 'Bearer ' + slackTokens[i]
+              'Authorization': 'Bearer ' + (slackTokens.length > 1 ? slackTokens[i] : slackTokens[0])
             },
             body: JSON.stringify({
               'channel': slackChannels[i],
@@ -196,7 +191,7 @@
     } else {
        const slackWebHooksUrls = slackWebHooksUrl.split(' '); // Multiple workspaces post support
        const slackChannels = slackChannel.split(' '); // Multiple channels post support
-       for(let i = 0; i < slackWebHooksUrls.length; i++) {
+       for(let i = 0; i < slackChannels.length; i++) {
         chrome.runtime.sendMessage(
           {
             contentScriptQuery: 'postMessage',

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -137,7 +137,7 @@
                     <div class="field-body">
                         <div class="field">
                         <div class="control">
-                            <input id="slackToken" class="input" type="password" placeholder="e.g. xoxp-xxx-xxx-xxx-xxx">
+                            <input id="slackToken" class="input" type="text" placeholder="e.g. xoxp-xxx-xxx-xxx-xxx">
                         </div>
                         <p class="help">ユーザーとしてメッセージ通知する場合に入力します。chat:write:userのパーミッションが必要です。<a target="blank" href="https://github.com/shoito/kot-chrome-assistant/wiki/Slack%E9%80%A3%E6%90%BA%E3%81%AE%E8%A8%AD%E5%AE%9A">トークンの取得方法</a></p>
                         </div>
@@ -303,7 +303,7 @@
                     <div class="field-body">
                         <div class="field">
                         <div class="control">
-                            <input id="slackStatusToken" class="input" type="password" placeholder="e.g. xoxp-xxx-xxx-xxx-xxx">
+                            <input id="slackStatusToken" class="input" type="text" placeholder="e.g. xoxp-xxx-xxx-xxx-xxx">
                         </div>
                         <p class="help">メッセージ通知と同じトークンでかまいません。users.profile:writeのパーミッションが必要です。<a target="blank" href="https://github.com/shoito/kot-chrome-assistant/wiki/Slack%E9%80%A3%E6%90%BA%E3%81%AE%E8%A8%AD%E5%AE%9A">トークンの取得方法</a></p>
                         </div>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -126,12 +126,12 @@ const postToSlack = () => {
   if (slackApiType === 'asUser') {
     const slackTokens = slackToken.split(' '); // Multiple workspaces post support
     const slackChannels = slackChannel.split(' ');  // For example, #ch1 #ch2 #ch3
-    for (let i = 0; i < slackTokens.length; i++) {
+    for (let i = 0; i < slackChannels.length; i++) {
       post('https://slack.com/api/chat.postMessage',
         {
           'Content-Type': 'application/json; charset=utf-8',
           'Access-Control-Allow-Origin': '*',
-          'Authorization': 'Bearer ' + slackTokens[i]
+          'Authorization': 'Bearer ' + (slackTokens.length > 1 ? slackTokens[i] : slackTokens[0])
         },
         {
           'channel': slackChannels[i],
@@ -143,7 +143,7 @@ const postToSlack = () => {
   } else {
     const slackWebHooksUrls = slackWebHooksUrl.split(' '); // Multiple workspaces post support
     const slackChannels = slackChannel.split(' '); // For example, #ch1 #ch2 #ch3
-    for (let i = 0; i < slackWebHooksUrls.length; i++) {
+    for (let i = 0; i < slackChannels.length; i++) {
       post(slackWebHooksUrls[i],
         {
           'Content-Type': 'application/json; charset=utf-8',


### PR DESCRIPTION
See https://github.com/shoito/kot-chrome-assistant/issues/19

WebHook URL も空白繋ぎで複数指定可能に。

## 同一ワークスペース、複数チャンネル
<img width="1183" alt="multi-channel" src="https://github.com/shoito/kot-chrome-assistant/assets/37051/ee6e8c2c-b912-4bc9-9ca3-e40a7d3066a6">

## 複数ワークスペース、複数チャンネル
<img width="1208" alt="multi-workspace" src="https://github.com/shoito/kot-chrome-assistant/assets/37051/51ac0795-3a32-489b-8c39-538e4ef06ce0">
