### PR TITLE
アクションボタンを押した時にポップアップ、新規タブで表示を切り替えできる機能を追加

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "MyレコーダーChromeアシスタント",
   "short_name": "Myレコーダーアシスト",
-  "version": "0.9.2.5",
+  "version": "0.9.3",
   "manifest_version": 3,
   "description": "勤怠管理システム「Myレコーダー | KING OF TIME」を快適に使えるようにするための拡張機能です。",
   "icons": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "MyレコーダーChromeアシスタント",
   "short_name": "Myレコーダーアシスト",
-  "version": "0.9.2",
+  "version": "0.9.2.4",
   "manifest_version": 3,
   "description": "勤怠管理システム「Myレコーダー | KING OF TIME」を快適に使えるようにするための拡張機能です。",
   "icons": {
@@ -15,13 +15,13 @@
   },
   "action": {
     "default_icon": "icons/icon19.png",
-    "default_title": "Myレコーダーアシスタント",
-    "default_popup": "src/browser_action/browser_action.html"
+    "default_title": "Myレコーダーアシスタント"
   },
   "permissions": [
     "storage",
     "declarativeNetRequest",
-    "declarativeNetRequestFeedback"
+    "declarativeNetRequestFeedback",
+    "tabs"
   ],
   "declarative_net_request": {
     "rule_resources": [{

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "MyレコーダーChromeアシスタント",
   "short_name": "Myレコーダーアシスト",
-  "version": "0.9.2.4",
+  "version": "0.9.2.5",
   "manifest_version": 3,
   "description": "勤怠管理システム「Myレコーダー | KING OF TIME」を快適に使えるようにするための拡張機能です。",
   "icons": {

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -62,7 +62,7 @@ chrome.action.onClicked.addListener(function() {
   let myrecUrl = "https://s2.ta.kingoftime.jp/independent/recorder/personal/";
 
   chrome.storage.sync.get(["openInNewTab", "s3Selected", "samlSelected"], (items) => {
-    if (data.openInNewTab) {
+    if (items.openInNewTab) {
       if (items.s3Selected || items.samlSelected) {
         const subdomain = !items.s3Selected ? "s2" : "s3";
         const recorder = !items.samlSelected ? "recorder" : "recorder2"
@@ -72,7 +72,7 @@ chrome.action.onClicked.addListener(function() {
       }
       chrome.tabs.query({ url: myrecUrl, currentWindow: true }, function(tabs) {
         if (tabs.length > 0) {
-          chrome.tabs.update(tabs[0].id, { active: true });
+          chrome.tabs.update(tabs[0].id, { active: true, url: myrecUrl }).catch(function(e){console.log(e.message)});
         } else {
           chrome.tabs.create({ url: myrecUrl }).catch(function(e){console.log(e.message)});
         }

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -47,3 +47,35 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   sendResponse({ 'status': 'listener is missing.\n' + msg });
   return true;
 });
+
+chrome.runtime.onInstalled.addListener(function() {
+  chrome.storage.sync.get('openInNewTab', function(data) {
+    if (data.openInNewTab) {
+      chrome.action.setPopup({ popup: '' });
+    } else {
+      chrome.action.setPopup({ popup: 'src/browser_action/browser_action.html' });
+    }
+  });
+});
+
+chrome.action.onClicked.addListener(function() {
+  let myrecUrl = "https://s2.ta.kingoftime.jp/independent/recorder/personal/";
+
+  chrome.storage.sync.get('openInNewTab', function(data) {
+    if (data.openInNewTab) {
+      chrome.storage.sync.get(["s3Selected", "samlSelected"], (items) => {
+        if (items.s3Selected || items.samlSelected) {
+          const subdomain = !items.s3Selected ? "s2" : "s3";
+          const recorder = !items.samlSelected ? "recorder" : "recorder2"
+    
+          myrecUrl = `https://${subdomain}.ta.kingoftime.jp/independent/${recorder}/personal/`;
+          chrome.tabs.create({ url: myrecUrl }).catch(function(e){console.log(e.message)});
+        } else {
+          chrome.tabs.create({ url: myrecUrl }).catch(function(e){console.log(e.message)});
+        }
+      });
+    } else {
+      chrome.action.openPopup();
+    }
+  });
+});

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -61,24 +61,24 @@ chrome.runtime.onInstalled.addListener(function() {
 chrome.action.onClicked.addListener(function() {
   let myrecUrl = "https://s2.ta.kingoftime.jp/independent/recorder/personal/";
 
-    chrome.storage.sync.get(["openInNewTab", "s3Selected", "samlSelected"], (items) => {
-      if (data.openInNewTab) {
-        if (items.s3Selected || items.samlSelected) {
-          const subdomain = !items.s3Selected ? "s2" : "s3";
-          const recorder = !items.samlSelected ? "recorder" : "recorder2"
-    
-          myrecUrl = `https://${subdomain}.ta.kingoftime.jp/independent/${recorder}/personal/`;
-          
-        }
-        chrome.tabs.query({ url: myrecUrl, currentWindow: true }, function(tabs) {
-          if (tabs.length > 0) {
-            chrome.tabs.update(tabs[0].id, { active: true });
-          } else {
-            chrome.tabs.create({ url: myrecUrl }).catch(function(e){console.log(e.message)});
-          }
-        });
-      } else {
-        chrome.action.openPopup();
+  chrome.storage.sync.get(["openInNewTab", "s3Selected", "samlSelected"], (items) => {
+    if (data.openInNewTab) {
+      if (items.s3Selected || items.samlSelected) {
+        const subdomain = !items.s3Selected ? "s2" : "s3";
+        const recorder = !items.samlSelected ? "recorder" : "recorder2"
+  
+        myrecUrl = `https://${subdomain}.ta.kingoftime.jp/independent/${recorder}/personal/`;
+        
       }
-    });
+      chrome.tabs.query({ url: myrecUrl, currentWindow: true }, function(tabs) {
+        if (tabs.length > 0) {
+          chrome.tabs.update(tabs[0].id, { active: true });
+        } else {
+          chrome.tabs.create({ url: myrecUrl }).catch(function(e){console.log(e.message)});
+        }
+      });
+    } else {
+      chrome.action.openPopup();
+    }
+  });
 });

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -61,21 +61,24 @@ chrome.runtime.onInstalled.addListener(function() {
 chrome.action.onClicked.addListener(function() {
   let myrecUrl = "https://s2.ta.kingoftime.jp/independent/recorder/personal/";
 
-  chrome.storage.sync.get('openInNewTab', function(data) {
-    if (data.openInNewTab) {
-      chrome.storage.sync.get(["s3Selected", "samlSelected"], (items) => {
+    chrome.storage.sync.get(["openInNewTab", "s3Selected", "samlSelected"], (items) => {
+      if (data.openInNewTab) {
         if (items.s3Selected || items.samlSelected) {
           const subdomain = !items.s3Selected ? "s2" : "s3";
           const recorder = !items.samlSelected ? "recorder" : "recorder2"
     
           myrecUrl = `https://${subdomain}.ta.kingoftime.jp/independent/${recorder}/personal/`;
-          chrome.tabs.create({ url: myrecUrl }).catch(function(e){console.log(e.message)});
-        } else {
-          chrome.tabs.create({ url: myrecUrl }).catch(function(e){console.log(e.message)});
+          
         }
-      });
-    } else {
-      chrome.action.openPopup();
-    }
-  });
+        chrome.tabs.query({ url: myrecUrl, currentWindow: true }, function(tabs) {
+          if (tabs.length > 0) {
+            chrome.tabs.update(tabs[0].id, { active: true });
+          } else {
+            chrome.tabs.create({ url: myrecUrl }).catch(function(e){console.log(e.message)});
+          }
+        });
+      } else {
+        chrome.action.openPopup();
+      }
+    });
 });

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -365,6 +365,25 @@
 
                 </div>
 
+                <h4>アクションボタン設定</h4>
+                <div id="action-button-settings" class="box">
+
+                    <div class="field is-horizontal">
+                    <div class="field-label is-normal">
+                        <label class="label">表示方法切り替え</label>
+                    </div>
+                    <div class="field-body">
+                        <label class="radio">
+                            <input id="openInPopupSelected" name="action-button" type="radio">ポップアップ表示
+                        </label>
+                        <label class="radio">
+                            <input id="openInNewTabSelected" name="action-button" type="radio">新規タブ表示
+                        </label>
+                    </div>
+                    </div>
+
+                </div>
+
                 <h4>お試しボタン</h4>
                 <div id="debuggable-settings" class="box">
 

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -94,7 +94,10 @@ const restoreOptions = () => {
     "s3Selected",
 
     // KING OF TIME Authentication
-    "samlSelected"
+    "samlSelected",
+
+    // Open in new tab
+    "openInNewTab"
   ], (items) => {
     document.getElementById('debuggable').checked = items.debuggable;
 
@@ -122,6 +125,9 @@ const restoreOptions = () => {
 
     document.getElementById('accountSelected').checked = !items.samlSelected;
     document.getElementById('samlSelected').checked = items.samlSelected;
+
+    document.getElementById('openInPopupSelected').checked = !items.openInNewTab;
+    document.getElementById('openInNewTabSelected').checked = items.openInNewTab;
   });
 }
 
@@ -229,6 +235,16 @@ document.getElementById('accountSelected').addEventListener('change', () => {
 
 document.getElementById('samlSelected').addEventListener('change', () => {
   chrome.storage.sync.set({samlSelected: true});
+});
+
+document.getElementById('openInPopupSelected').addEventListener('change', () => {
+  chrome.storage.sync.set({openInNewTab: false});
+  chrome.action.setPopup({ popup: 'src/browser_action/browser_action.html' });
+});
+
+document.getElementById('openInNewTabSelected').addEventListener('change', () => {
+  chrome.storage.sync.set({openInNewTab: true});
+  chrome.action.setPopup({ popup: '' });
 });
 
 document.getElementById('debuggable').addEventListener('click', () => {


### PR DESCRIPTION
See #41

SAML認証のページがiframeの制限により表示できなくなったことへの対策として、新規タブで開く機能とオプションページに設定項目を追加しました。

## Before

![スクリーンショット 2024-06-13 12 45 37](https://github.com/shoito/kot-chrome-assistant/assets/15701307/d0032d03-5a4c-45eb-9ca1-4f5296e7e1a3)

## After
![スクリーンショット 2024-06-13 12 45 53](https://github.com/shoito/kot-chrome-assistant/assets/15701307/b8ade83e-e4d3-4468-adb9-3df7e951a147)
